### PR TITLE
chore: remove expired cert

### DIFF
--- a/stretch-arm64/Dockerfile
+++ b/stretch-arm64/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   unzip
 
+# Remove expired CA cert for openSSL 1.0.2
+# https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
+RUN rm -f /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
+RUN update-ca-certificates --fresh
+
 ENV AS=/usr/bin/aarch64-linux-gnu-as \
   AR=/usr/bin/aarch64-linux-gnu-ar \
   CC=/usr/bin/aarch64-linux-gnu-gcc \

--- a/stretch-armhf/Dockerfile
+++ b/stretch-armhf/Dockerfile
@@ -17,6 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   unzip
 
+# Remove expired CA cert for openSSL 1.0.2
+# https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
+RUN rm -f /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
+RUN update-ca-certificates --fresh
+
 ENV AS=/usr/bin/arm-linux-gnueabihf-as \
   AR=/usr/bin/arm-linux-gnueabihf-ar \
   CC=/usr/bin/arm-linux-gnueabihf-gcc \


### PR DESCRIPTION
I am working on implementing a long term solution of building latest curl from source here https://github.com/microsoft/vscode-linux-build-agent/tree/robo/fix_curl_stretch

Making this change temporarily to unblock the builds