### PR TITLE
chore: add x64 centos7-devtoolset8 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,14 @@ jobs:
     parameters:
       arch: bionic-x64
 
+- job: centos7_devtoolset8_x64
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+  - template: build.yml
+    parameters:
+      arch: centos7-devtoolset8-x64
+
 - job: armhf
   pool:
     vmImage: 'ubuntu-latest'

--- a/centos7-devtoolset8-x64/Dockerfile
+++ b/centos7-devtoolset8-x64/Dockerfile
@@ -1,0 +1,29 @@
+FROM centos:centos7
+
+ARG INSTALL_PKGS="devtoolset-8-gcc \
+    devtoolset-8-gcc-c++ \
+    devtoolset-8-gcc-gfortran \
+    devtoolset-8-gdb \
+    make \
+    git \
+    sudo \
+    libsecret-devel \
+    nodejs \
+    python3"
+
+# setup nodejs repo
+RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
+
+RUN yum install -y centos-release-scl-rh && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum -y clean all --enablerepo='*'
+
+# update npm and install yarn
+RUN npm install -g npm@latest
+RUN npm install -g yarn
+
+ENV PATH=/opt/rh/devtoolset-8/root/usr/bin/:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN mkdir -p /root/vscode
+WORKDIR /root/vscode


### PR DESCRIPTION
This is first step is getting x64 remote modules build on the same toolchain as official node https://github.com/nodejs/node/blob/master/BUILDING.md#official-binary-platforms-and-toolchains