### PR TITLE
ci: bump alpine base image for arm64 and x64

### DIFF
--- a/alpine-arm64/Dockerfile
+++ b/alpine-arm64/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm64v8/alpine:3.16
 
-RUN apk add g++ python make git bash curl perl pkgconfig libsecret-dev && uname -m
+RUN apk add g++ python3 make git bash curl perl pkgconfig libsecret-dev && uname -m
 
 RUN mkdir -p /root/vscode
 WORKDIR /root/vscode

--- a/alpine-arm64/Dockerfile
+++ b/alpine-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/node:14.16.0-alpine
+FROM arm64v8/alpine:3.16
 
 RUN apk add g++ python make git bash curl perl pkgconfig libsecret-dev && uname -m
 

--- a/alpine-x64/Dockerfile
+++ b/alpine-x64/Dockerfile
@@ -1,5 +1,5 @@
-ARG REPO=node
-ARG TAG=14.16.0-alpine
+ARG REPO=alpine
+ARG TAG=3.16
 FROM ${REPO}:${TAG}
 
 RUN apk add g++ python make git bash curl perl pkgconfig libsecret-dev

--- a/alpine-x64/Dockerfile
+++ b/alpine-x64/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=alpine
 ARG TAG=3.16
 FROM ${REPO}:${TAG}
 
-RUN apk add g++ python make git bash curl perl pkgconfig libsecret-dev
+RUN apk add g++ python3 make git bash curl perl pkgconfig libsecret-dev
 
 RUN mkdir -p /root/vscode
 WORKDIR /root/vscode


### PR DESCRIPTION
Needed to address CG alerts reported in https://github.com/microsoft/vscode-internalbacklog/issues/4467#issuecomment-1636290933

This will bump the minimum libstdc++ version for our native modules, we have verified the user count from server telemetry and decided to push this forward.

/cc @joaomoreno 