### PR TITLE
ci: update gcc version for bionic-arm32v7 agent

### DIFF
--- a/bionic-arm32v7/Dockerfile
+++ b/bionic-arm32v7/Dockerfile
@@ -7,8 +7,8 @@ RUN groupadd --gid 1000 builduser \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   software-properties-common \
-  gcc \
-  g++ \
+  gcc-8 \
+  g++-8 \
   binutils \
   build-essential \
   git \
@@ -33,3 +33,7 @@ RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
 
 USER builduser
 WORKDIR /home/builduser
+
+ENV CC=/usr/bin/gcc-8 \
+  CPP=/usr/bin/cpp-8 \
+  CXX=/usr/bin/g++-8

--- a/bionic-arm64/Dockerfile
+++ b/bionic-arm64/Dockerfile
@@ -44,21 +44,18 @@ RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python --version
 
-# Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
-
-# Node.js
-RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
-RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g node-gyp
-
 # Install docker client
 RUN sudo mkdir -m 0755 -p /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN sudo apt-get update && sudo apt-get install -y docker-ce
+RUN apt-get update && apt-get install -y docker-ce
+
+# Node.js
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+RUN npm install -g yarn
+RUN npm install -g node-gyp
 
 USER builduser
 WORKDIR /home/builduser

--- a/bionic-arm64/Dockerfile
+++ b/bionic-arm64/Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get update && apt-get install -y yarn
 # Node.js
 RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g npm@latest
 RUN npm install -g node-gyp
 
 # Install docker client

--- a/bionic-armhf/Dockerfile
+++ b/bionic-armhf/Dockerfile
@@ -44,21 +44,18 @@ RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python --version
 
-# Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
-
-# Node.js
-RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
-RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g node-gyp
-
 # Install docker client
 RUN sudo mkdir -m 0755 -p /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN sudo apt-get update && sudo apt-get install -y docker-ce
+RUN apt-get update && apt-get install -y docker-ce
+
+# Node.js
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+RUN npm install -g yarn
+RUN npm install -g node-gyp
 
 USER builduser
 WORKDIR /home/builduser

--- a/bionic-armhf/Dockerfile
+++ b/bionic-armhf/Dockerfile
@@ -52,7 +52,6 @@ RUN apt-get update && apt-get install -y yarn
 # Node.js
 RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g npm@latest
 RUN npm install -g node-gyp
 
 # Install docker client

--- a/bionic-x64/Dockerfile
+++ b/bionic-x64/Dockerfile
@@ -66,7 +66,6 @@ RUN apt-get update && apt-get install -y yarn
 # Node.js
 RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
 RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g npm@latest
 RUN npm install -g node-gyp
 
 # Set python3 as default

--- a/bionic-x64/Dockerfile
+++ b/bionic-x64/Dockerfile
@@ -58,16 +58,6 @@ RUN apt-get update && apt-get install -y \
 RUN echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-builduser \
   && echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 
-# Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
-
-# Node.js
-RUN curl --silent --location https://deb.nodesource.com/setup_16.x | sudo -E bash -
-RUN apt-get update && apt-get install -y nodejs
-RUN npm install -g node-gyp
-
 # Set python3 as default
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 RUN python --version
@@ -76,7 +66,14 @@ RUN python --version
 RUN sudo mkdir -m 0755 -p /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 RUN echo "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-RUN sudo apt-get update && sudo apt-get install -y docker-ce
+RUN apt-get update && apt-get install -y docker-ce
+
+# Node.js
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update && apt-get install -y nodejs
+RUN npm install -g yarn
+RUN npm install -g node-gyp
 
 # Check compiler toolchain
 RUN gcc --version

--- a/centos7-devtoolset8-arm64/Dockerfile
+++ b/centos7-devtoolset8-arm64/Dockerfile
@@ -22,7 +22,6 @@ RUN yum install -y centos-release-scl-rh && \
     yum -y clean all --enablerepo='*'
 
 # update npm and install yarn, node-gyp
-RUN npm install -g npm@latest
 RUN npm install -g yarn
 RUN npm install -g node-gyp
 

--- a/centos7-devtoolset8-arm64/Dockerfile
+++ b/centos7-devtoolset8-arm64/Dockerfile
@@ -10,18 +10,16 @@ ARG INSTALL_PKGS="devtoolset-8-gcc \
     sudo \
     libsecret-devel \
     krb5-devel \
-    nodejs \
     python3"
-
-# setup nodejs repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
 
 RUN yum install -y centos-release-scl-rh && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 
-# update npm and install yarn, node-gyp
+# install nodejs
+RUN yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
+RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 RUN npm install -g yarn
 RUN npm install -g node-gyp
 

--- a/centos7-devtoolset8-x64/Dockerfile
+++ b/centos7-devtoolset8-x64/Dockerfile
@@ -24,7 +24,6 @@ RUN yum install -y centos-release-scl-rh && \
     yum -y clean all --enablerepo='*'
 
 # update npm and install yarn, node-gyp
-RUN npm install -g npm@latest
 RUN npm install -g yarn
 RUN npm install -g node-gyp
 

--- a/centos7-devtoolset8-x64/Dockerfile
+++ b/centos7-devtoolset8-x64/Dockerfile
@@ -12,18 +12,16 @@ ARG INSTALL_PKGS="devtoolset-8-gcc \
     sudo \
     libsecret-devel \
     krb5-devel \
-    nodejs \
     python3"
-
-# setup nodejs repo
-RUN curl --silent --location https://rpm.nodesource.com/setup_16.x | bash -
 
 RUN yum install -y centos-release-scl-rh && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum -y clean all --enablerepo='*'
 
-# update npm and install yarn, node-gyp
+# install nodejs
+RUN yum install https://rpm.nodesource.com/pub_16.x/nodistro/repo/nodesource-release-nodistro-1.noarch.rpm -y
+RUN yum install nodejs -y --setopt=nodesource-nodejs.module_hotfixes=1
 RUN npm install -g yarn
 RUN npm install -g node-gyp
 


### PR DESCRIPTION
Needed for https://dev.azure.com/monacotools/Monaco/_build/results?buildId=228109&view=logs&jobId=240902e7-d32c-539b-e2e9-5bc1a996cfb5&j=240902e7-d32c-539b-e2e9-5bc1a996cfb5&t=e6037e91-d2a8-5cdb-287d-cc8825137707

**Other Changes:**

- Migrate nodesource scripts to actual package downloads, refs https://github.com/nodesource/distributions#new-update-%EF%B8%8F


PS: Changes in this PR are no-op for VSCode pipelines